### PR TITLE
Split Rays on hit

### DIFF
--- a/test/astary.test.ts
+++ b/test/astary.test.ts
@@ -287,6 +287,23 @@ describe('raycast', () => {
             expect(con[0].edges.size).toEqual(1);
             expect(con[0].edges).toContain(1);
         });
+        it('should split the ray correctly', () => {
+            const con = astar.Raycast(
+                [
+                    { x: -5, y: 5, edges: new Set() },
+                    { x: 5, y: 5, edges: new Set() },
+                    { x: 0, y: 0, edges: new Set() },
+                ],
+                [
+                    { sx: -3, sy: -1, ex: -3, ey: 4 },
+                    { sx: 3, sy: -1, ex: 3, ey: 4 },
+                ]
+            );
+            console.log(con);
+            expect(con.filter((x) => x.raycast)).toHaveLength(1); // only 1 raycasted node
+            expect(astar.AStar(2, 0, con)).toHaveLength(3);
+            expect(astar.AStar(2, 1, con)).toHaveLength(3);
+        });
     });
 });
 /*describe('makeGraph', () => {

--- a/visualize/steppy/steppy.ts
+++ b/visualize/steppy/steppy.ts
@@ -9,6 +9,7 @@ import {
     Point,
     RayE,
 } from '../../src/astar';
+console.clear = () => {};
 const s = 16;
 const nodes: Node[] = JSON.parse(
     localStorage.getItem('nodes') ||


### PR DESCRIPTION
When we hit a ray, we need to split it and update references accordingly.

old behavior
![image](https://user-images.githubusercontent.com/32279125/194360574-064b4778-5e74-42f8-b72a-ce1684745cd0.png)

what this pr will implement
![image](https://user-images.githubusercontent.com/32279125/194360746-28ec8fb5-dbf1-4b67-9a1b-f4025c6ae9a8.png)

please excuse the drawings


